### PR TITLE
Improve format of note update notifications

### DIFF
--- a/testsuite/tests/LC24-001__add_one_note/test.py
+++ b/testsuite/tests/LC24-001__add_one_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for d065089ff184d97934c010ccd0e7e8ed94cb7165
+remote: Subject: [notes][repo] New file: a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote: X-Git-Newrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my new note.
 remote:

--- a/testsuite/tests/LC24-001__add_two_notes/test.py
+++ b/testsuite/tests/LC24-001__add_two_notes/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for d065089ff184d97934c010ccd0e7e8ed94cb7165
+remote: Subject: [notes][repo] New file: a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote: X-Git-Newrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my new note.
 remote:
@@ -49,14 +49,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for 52abc3c195e80fa1713f2603290b6b202484694b
+remote: Subject: [notes][repo] Separate subject from body with empty line in file a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote: X-Git-Newrev: 0892f7e8d41c265fc0ffcbe604f0e7ce784bd9d2
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     Another short note.
 remote:

--- a/testsuite/tests/LC24-001__create_notes_one_note/test.py
+++ b/testsuite/tests/LC24-001__create_notes_one_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev:
 remote: X-Git-Newrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:

--- a/testsuite/tests/LC24-001__create_notes_two_notes/test.py
+++ b/testsuite/tests/LC24-001__create_notes_two_notes/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev:
 remote: X-Git-Newrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:
@@ -52,14 +52,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for d065089ff184d97934c010ccd0e7e8ed94cb7165
+remote: Subject: [notes][repo] New file: a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote: X-Git-Newrev: a0cd78e7b5d7bab7a956489837bf61f7a6376527
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my second note.
 remote:

--- a/testsuite/tests/LC24-001__delete_one_note/test.py
+++ b/testsuite/tests/LC24-001__delete_one_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote: X-Git-Newrev: 5caa78def00f5293b84b13285d17f56844478d78
 remote:
-remote: The Git Notes annotating the following commit has been deleted.
+remote: Git notes annotating the following commit have been deleted.
 remote:
 remote: commit a60540361d47901d3fe254271779f380d94645f7
 remote: Author: Joel Brobecker <brobecker@adacore.com>

--- a/testsuite/tests/LC24-001__update_one_note/test.py
+++ b/testsuite/tests/LC24-001__update_one_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote: X-Git-Newrev: da34a4b05e4d30a714577a9cc46c199df1634838
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:     Add some information about my first note.

--- a/testsuite/tests/LC24-001__update_same_note_twice/test.py
+++ b/testsuite/tests/LC24-001__update_same_note_twice/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote: X-Git-Newrev: da34a4b05e4d30a714577a9cc46c199df1634838
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:     Add some information about my first note.
@@ -53,14 +53,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: da34a4b05e4d30a714577a9cc46c199df1634838
 remote: X-Git-Newrev: d10873b25a129aa60cdd2dcfbbae9331cef7d677
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:     Rewrite a little bit how I added some information.

--- a/testsuite/tests/LC24-001__update_then_delete_note/test.py
+++ b/testsuite/tests/LC24-001__update_then_delete_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote: X-Git-Newrev: da34a4b05e4d30a714577a9cc46c199df1634838
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my first note.
 remote:     Add some information about my first note.
@@ -53,14 +53,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for a60540361d47901d3fe254271779f380d94645f7
+remote: Subject: [notes][repo] Updated a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: da34a4b05e4d30a714577a9cc46c199df1634838
 remote: X-Git-Newrev: 827773c6b58569e16fbb3bd0f639a9d804687fc4
 remote:
-remote: The Git Notes annotating the following commit has been deleted.
+remote: Git notes annotating the following commit have been deleted.
 remote:
 remote: commit a60540361d47901d3fe254271779f380d94645f7
 remote: Author: Joel Brobecker <brobecker@adacore.com>

--- a/testsuite/tests/N707-041__notes_parasite/test.py
+++ b/testsuite/tests/N707-041__notes_parasite/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for 52393869d6041893f83a32692f31313997125d5b
+remote: Subject: [notes][repo] New file.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: a1debe299a88f46dd84c5f1392a0a87a17f5dac5
 remote: X-Git-Newrev: a137508589e324b68734d3c7f8f4fb4fbac5e3cb
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     Annotating the first commit...
 remote:

--- a/testsuite/tests/NC07-001__mailinglist_script/test.py
+++ b/testsuite/tests/NC07-001__mailinglist_script/test.py
@@ -383,14 +383,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: bfd-cvs@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for 4207b94cadc3c1be0edb4f6df5670f0311c267f3
+remote: Subject: [notes][repo] A binutils change.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev:
 remote: X-Git-Newrev: f92c5af7ed4374d7174b8e7c25cd89cea5c1b6c3
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     A bfd note.
 remote:
@@ -420,14 +420,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: gdb-cvs@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for cd2f5d40776eee5a47dc821eddd9a7c6c0ed436d
+remote: Subject: [notes][repo] Add start_mainloop declaration in top.h.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: f92c5af7ed4374d7174b8e7c25cd89cea5c1b6c3
 remote: X-Git-Newrev: dc30675096eb6cc1fc91f14286582387dd0d5183
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     A short GDB note.
 remote:
@@ -455,14 +455,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: bfd-cvs@example.com, gdb-cvs@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for 4c7588eee23d6d42e8d50ba05343e3d0f31dd286
+remote: Subject: [notes][repo] Add filename in struct bfd, and add README in GDB.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/commits
 remote: X-Git-Oldrev: dc30675096eb6cc1fc91f14286582387dd0d5183
 remote: X-Git-Newrev: 83820cec54feb2b77847ddab68534eeed84c2d0d
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     Synchronized change between binutils and GDB.
 remote:

--- a/testsuite/tests/S724-017__add_deploy_note/test.py
+++ b/testsuite/tests/S724-017__add_deploy_note/test.py
@@ -14,14 +14,14 @@ remote: Content-Transfer-Encoding: 7bit
 remote: From: Test Suite <testsuite@adacore.com>
 remote: To: git-hooks-ci@example.com
 remote: Bcc: file-ci@gnat.com
-remote: Subject: [repo] notes update for d065089ff184d97934c010ccd0e7e8ed94cb7165
+remote: Subject: [notes(deploy)][repo] New file: a.
 remote: X-Act-Checkin: repo
 remote: X-Git-Author: Joel Brobecker <brobecker@adacore.com>
 remote: X-Git-Refname: refs/notes/deploy
 remote: X-Git-Oldrev: bbcc356176bb7f3104788323566c4fcef70650fc
 remote: X-Git-Newrev: 58e8efaaf0dee13edea66b1abbd4b669132b3d77
 remote:
-remote: A Git Notes has been updated; it now contains:
+remote: A Git note has been updated; it now contains:
 remote:
 remote:     This is my new note.
 remote:


### PR DESCRIPTION
Include original commit name and note ref name (if not default)
in subject.

Minor wording tweaks.

for S724-027

Change-Id: I9660c19876627c1259e9b7a42ea7b2f9f9669f43