### PR TITLE
Convert print statements to print function

### DIFF
--- a/hooks/daemon.py
+++ b/hooks/daemon.py
@@ -1,6 +1,7 @@
 """A module to handle daemonization...
 """
 
+from __future__ import print_function
 import os
 import sys
 from syslog import syslog
@@ -85,5 +86,5 @@ def run_in_daemon(fun):
         if daemon_pipe[0] is not None:
             os.close(daemon_pipe[1])
             daemon_stdout = os.fdopen(daemon_pipe[0])
-            print >> sys.stderr, daemon_stdout.read(),
+            print(daemon_stdout.read(), file=sys.stderr, end='')
             daemon_stdout.close()

--- a/hooks/syslog.py
+++ b/hooks/syslog.py
@@ -1,6 +1,7 @@
 """Handling of syslog-ing...
 """
 
+from __future__ import print_function
 from os import environ
 from subprocess import Popen, PIPE, STDOUT
 
@@ -33,4 +34,4 @@ def syslog(message, tag='style_checker', priority='local0.warn'):
         warn(*info)
 
     elif out.rstrip():
-        print out.rstrip()
+        print(out.rstrip())

--- a/hooks/updates/emails.py
+++ b/hooks/updates/emails.py
@@ -1,5 +1,6 @@
 """Email helpers for sending update-related emails."""
 
+from __future__ import print_function
 from config import git_config
 from email.header import Header
 from email.mime.text import MIMEText
@@ -326,7 +327,7 @@ class Email(object):
         p = Popen(self.filer_cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
         out, _ = p.communicate(to_be_filed)
         if p.returncode != 0:
-            print out
+            print(out)
 
 
 def guess_encoding(text):

--- a/hooks/updates/sendmail.py
+++ b/hooks/updates/sendmail.py
@@ -1,5 +1,6 @@
 """A module to send emails...
 """
+from __future__ import print_function
 import os
 from subprocess import Popen, PIPE, STDOUT
 
@@ -26,7 +27,7 @@ def sendmail(from_email, to_emails, mail_as_string, smtp_server):
                       stdin=PIPE, stdout=PIPE, stderr=STDOUT)
             out, _ = p.communicate(mail_as_string)
             if p.returncode != 0:
-                print out
+                print(out)
             return p.returncode == 0
 
     # Else try using smtplib

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from datetime import datetime
 from os import environ
 import os
@@ -130,7 +131,7 @@ def warn(*args, **kwargs):
     """
     prefix = kwargs['prefix'] if 'prefix' in kwargs else '*** '
     for arg in args:
-        print >> sys.stderr, "%s%s" % (prefix, arg)
+        print("%s%s" % (prefix, arg), file=sys.stderr)
 
 
 ############################################################################

--- a/testsuite/lib/testsuite.py
+++ b/testsuite/lib/testsuite.py
@@ -4,6 +4,7 @@
 Driver for the git hooks testsuite.
 """
 
+from __future__ import print_function
 from gnatpython.fileutils import rm
 from gnatpython.main import Main
 from gnatpython.mainloop import (MainLoop, add_mainloop_options,
@@ -69,13 +70,13 @@ def print_testsuite_results_summary(metrics):
     ARGUMENTS
         metrics: Same as in gnatpython.mainloop.generate_collect_result.
     """
-    print """\
+    print("""\
 
 Testsuite Results Summary -- Out of %(run)d testscase(s) run in total:
 
     %(failed)4d testcase(s) failed
     %(crashed)4d testcase(s) crashed
-""" % metrics
+""" % metrics)
 
 
 def main():

--- a/testsuite/lib/utils.py
+++ b/testsuite/lib/utils.py
@@ -1,6 +1,7 @@
 """A module providing some generally useful stuff.
 """
 
+from __future__ import print_function
 import sys
 
 def abort(exit_code=0):
@@ -26,7 +27,7 @@ def fatal_error(msg):
     PARAMETERS
       msg: The error message to print.
     """
-    print "*** Error: " + msg
+    print("*** Error: " + msg)
     abort(1)
 
 

--- a/testsuite/tests/L327-022__minor_instead_of_tn/cvs_check.py
+++ b/testsuite/tests/L327-022__minor_instead_of_tn/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L327-022__minority_is_not_minor/cvs_check.py
+++ b/testsuite/tests/L327-022__minority_is_not_minor/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L327-022__missing_tn/cvs_check.py
+++ b/testsuite/tests/L327-022__missing_tn/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L327-022__no-tn-check_instead_of_tn/cvs_check.py
+++ b/testsuite/tests/L327-022__no-tn-check_instead_of_tn/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L327-022__tn_check/cvs_check.py
+++ b/testsuite/tests/L327-022__tn_check/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L327-022__tnrequired_noprecommitcheck/cvs_check.py
+++ b/testsuite/tests/L327-022__tnrequired_noprecommitcheck/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L424-035__retired_branch/cvs_check.py
+++ b/testsuite/tests/L424-035__retired_branch/cvs_check.py
@@ -4,10 +4,11 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L427-027__push_single_commit/cvs_check.py
+++ b/testsuite/tests/L427-027__push_single_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L502-002__a_tag_before_commit/cvs_check.py
+++ b/testsuite/tests/L502-002__a_tag_before_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L510-048__one_commit_multiple_files/cvs_check.py
+++ b/testsuite/tests/L510-048__one_commit_multiple_files/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L510-049__multiple_commits/cvs_check.py
+++ b/testsuite/tests/L510-049__multiple_commits/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L510-052__one_file_added/cvs_check.py
+++ b/testsuite/tests/L510-052__one_file_added/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L510-053__multiple_files_added/cvs_check.py
+++ b/testsuite/tests/L510-053__multiple_files_added/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L510-055__reject_modified_file/cvs_check.py
+++ b/testsuite/tests/L510-055__reject_modified_file/cvs_check.py
@@ -4,19 +4,19 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'b':
-        print >> sys.stderr, \
-            'ERROR: %s: Copyright year in header is not up to date' % filename
+        print('ERROR: %s: Copyright year in header is not up to date' % filename, file=sys.stderr)
         sys.exit(1)

--- a/testsuite/tests/L510-056__reject_added_file/cvs_check.py
+++ b/testsuite/tests/L510-056__reject_added_file/cvs_check.py
@@ -4,20 +4,20 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'pck.ads':
-	print >> sys.stderr, \
-	    "ERROR: style-check error detected for file: `%s'." % filename
-	print >> sys.stderr, 'ERROR: Copyright year in header is not up to date'
+	print("ERROR: style-check error detected for file: `%s'." % filename, file=sys.stderr)
+	print('ERROR: Copyright year in header is not up to date', file=sys.stderr)
 	sys.exit(1)

--- a/testsuite/tests/L511-038__l_tag_before_commit/cvs_check.py
+++ b/testsuite/tests/L511-038__l_tag_before_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L512-001__forced_update_on_topic/cvs_check.py
+++ b/testsuite/tests/L512-001__forced_update_on_topic/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L512-002__forced_update_precommit_err/cvs_check.py
+++ b/testsuite/tests/L512-002__forced_update_precommit_err/cvs_check.py
@@ -4,20 +4,20 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'b':
-        print >> sys.stderr, \
-            'ERROR: %s: Copyright header is missing from this file' % filename
+        print('ERROR: %s: Copyright header is missing from this file' % filename, file=sys.stderr)
         sys.exit(1)
 

--- a/testsuite/tests/L610-006__new_branch_from_head/cvs_check.py
+++ b/testsuite/tests/L610-006__new_branch_from_head/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L610-007__new_branch_from_older_commit/cvs_check.py
+++ b/testsuite/tests/L610-007__new_branch_from_older_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L610-010__reject_file_rename/cvs_check.py
+++ b/testsuite/tests/L610-010__reject_file_rename/cvs_check.py
@@ -4,19 +4,19 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'b':
-        print >> sys.stderr, \
-            'ERROR: %s: Copyright year in header is not up to date' % filename
+        print('ERROR: %s: Copyright year in header is not up to date' % filename, file=sys.stderr)
         sys.exit(1)

--- a/testsuite/tests/L610-011__reject_new_branch_from_head/cvs_check.py
+++ b/testsuite/tests/L610-011__reject_new_branch_from_head/cvs_check.py
@@ -4,20 +4,20 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'b':
-        print >> sys.stderr, \
-            'ERROR: %s: Copyright year in header is not up to date' % filename
+        print('ERROR: %s: Copyright year in header is not up to date' % filename, file=sys.stderr)
         sys.exit(1)
 

--- a/testsuite/tests/L610-012__reject_new_branch_from_older/cvs_check.py
+++ b/testsuite/tests/L610-012__reject_new_branch_from_older/cvs_check.py
@@ -4,19 +4,19 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'c':
-        print >> sys.stderr, \
-            'ERROR: %s: Copyright year in header is not up to date' % filename
+        print('ERROR: %s: Copyright year in header is not up to date' % filename, file=sys.stderr)
         sys.exit(1)

--- a/testsuite/tests/L610-013__rename_one_file/cvs_check.py
+++ b/testsuite/tests/L610-013__rename_one_file/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L611-001__gitattr_no_precommit_check/cvs_check.py
+++ b/testsuite/tests/L611-001__gitattr_no_precommit_check/cvs_check.py
@@ -4,15 +4,16 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
         ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-        ' '.join(["`%s'" % arg for arg in filenames]))
+        ' '.join(["`%s'" % arg for arg in filenames])))
 
 # We should never be called for file `b', because the user requested
 # that this file not have pre-commit checks run on it (via a .gitattribute
@@ -20,5 +21,5 @@ print "cvs_check: %s < %s" % (
 
 for filename in filenames:
     if filename == 'b':
-	print "Error: Style violations detected in file: %s" % filename
+	print("Error: Style violations detected in file: %s" % filename)
 	sys.exit(1)

--- a/testsuite/tests/L611-002__default_no_precommit_check/cvs_check.py
+++ b/testsuite/tests/L611-002__default_no_precommit_check/cvs_check.py
@@ -4,15 +4,16 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # We should never be called for file `b', because the user requested
 # that this file not have pre-commit checks run on it (via a .gitattribute
@@ -20,5 +21,5 @@ print >> sys.stderr, "cvs_check: %s < %s" % (
 
 for filename in filenames:
     if filename == 'b':
-        print "Error: Style violations detected in file: %s" % filename
+        print("Error: Style violations detected in file: %s" % filename)
         sys.exit(1)

--- a/testsuite/tests/L615-033__headless_branch/cvs_check.py
+++ b/testsuite/tests/L615-033__headless_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L620-037__headless_branch_combined/cvs_check.py
+++ b/testsuite/tests/L620-037__headless_branch_combined/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L620-040__combined_push_single_commit/cvs_check.py
+++ b/testsuite/tests/L620-040__combined_push_single_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L620-041__combined_multiple_commits/cvs_check.py
+++ b/testsuite/tests/L620-041__combined_multiple_commits/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L625-038__update_l_tag/cvs_check.py
+++ b/testsuite/tests/L625-038__update_l_tag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L628-049__update_tag/cvs_check.py
+++ b/testsuite/tests/L628-049__update_tag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/L628-051__noemail_branch/cvs_check.py
+++ b/testsuite/tests/L628-051__noemail_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LB24-002__NB_push_one_commit/cvs_check.py
+++ b/testsuite/tests/LB24-002__NB_push_one_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC10-005__missing_fromdomain/cvs_check.py
+++ b/testsuite/tests/LC10-005__missing_fromdomain/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC10-006__new_branch_existing_commit/cvs_check.py
+++ b/testsuite/tests/LC10-006__new_branch_existing_commit/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC11-003__delete_branch/cvs_check.py
+++ b/testsuite/tests/LC11-003__delete_branch/cvs_check.py
@@ -4,11 +4,12 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))
 

--- a/testsuite/tests/LC20-007__merge_commit_branch_update/cvs_check.py
+++ b/testsuite/tests/LC20-007__merge_commit_branch_update/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-009__merge_commit_new_branch/cvs_check.py
+++ b/testsuite/tests/LC20-009__merge_commit_new_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-020__merge_commit_branch_update/cvs_check.py
+++ b/testsuite/tests/LC20-020__merge_commit_branch_update/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-021__merge_commit_new_branch/cvs_check.py
+++ b/testsuite/tests/LC20-021__merge_commit_new_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-034__lost_revs_delete_branch/cvs_check.py
+++ b/testsuite/tests/LC20-034__lost_revs_delete_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-039__lost_revs_delete_atag/cvs_check.py
+++ b/testsuite/tests/LC20-039__lost_revs_delete_atag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-040__lost_revs_delete_ltag/cvs_check.py
+++ b/testsuite/tests/LC20-040__lost_revs_delete_ltag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-041__empty_line_after_subject/cvs_check.py
+++ b/testsuite/tests/LC20-041__empty_line_after_subject/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC20-045__branch_no_precommit_check/cvs_check.py
+++ b/testsuite/tests/LC20-045__branch_no_precommit_check/cvs_check.py
@@ -1,15 +1,16 @@
 #! /usr/bin/env python
 """A dummy cvs_check program that fails all files.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
-print >> sys.stderr, 'ERROR: style-check should not be performed.'
+print('ERROR: style-check should not be performed.', file=sys.stderr)
 sys.exit(1)

--- a/testsuite/tests/LC23-001__bad_merge_commits/cvs_check.py
+++ b/testsuite/tests/LC23-001__bad_merge_commits/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC27-002__nocvscheck_user_override/cvs_check.py
+++ b/testsuite/tests/LC27-002__nocvscheck_user_override/cvs_check.py
@@ -4,13 +4,13 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 assert (filenames)
 
 # Fail the style-check.
-print >> sys.stderr, \
-    'ERROR: %s: Copyright year in header is not up to date' % filenames[0]
+print('ERROR: %s: Copyright year in header is not up to date' % filenames[0], file=sys.stderr)
 sys.exit(1)
 

--- a/testsuite/tests/LC27-005__no_file_ci_bcc/cvs_check.py
+++ b/testsuite/tests/LC27-005__no_file_ci_bcc/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC28-004__invalid_bool_config_value/cvs_check.py
+++ b/testsuite/tests/LC28-004__invalid_bool_config_value/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC28-006__diff_truncated/cvs_check.py
+++ b/testsuite/tests/LC28-006__diff_truncated/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/LC28-010__daemon_utest/test.py
+++ b/testsuite/tests/LC28-010__daemon_utest/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from support import *
 import errno
 import os
@@ -33,7 +34,7 @@ def utest_fork():
 
 # A small function to use as argument for run_in_daemon.
 def hello_world():
-    print "Hello World!"
+    print("Hello World!")
 
 
 class TestRun(TestCase):

--- a/testsuite/tests/LC29-002__multiple_no_precommit_check/cvs_check.py
+++ b/testsuite/tests/LC29-002__multiple_no_precommit_check/cvs_check.py
@@ -1,15 +1,16 @@
 #! /usr/bin/env python
 """A dummy cvs_check program that fails all files.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
-print >> sys.stderr, 'ERROR: style-check should not be performed.'
+print('ERROR: style-check should not be performed.', file=sys.stderr)
 sys.exit(1)

--- a/testsuite/tests/LC30-006__no_email_regexp/cvs_check.py
+++ b/testsuite/tests/LC30-006__no_email_regexp/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/M417-001__no_rh_precommit_checks/cvs_check.py
+++ b/testsuite/tests/M417-001__no_rh_precommit_checks/cvs_check.py
@@ -4,12 +4,12 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 for filename in filenames:
     if filename == 'b':
-        print >>sys.stderr, \
-            "cvs_check: style check violation in %s" % filename
+        print("cvs_check: style check violation in %s" % filename, file=sys.stderr)
         sys.exit(1)

--- a/testsuite/tests/M424-008__no_rh_check_keyword/cvs_check.py
+++ b/testsuite/tests/M424-008__no_rh_check_keyword/cvs_check.py
@@ -4,18 +4,19 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
         ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-        ' '.join(["`%s'" % arg for arg in filenames]))
+        ' '.join(["`%s'" % arg for arg in filenames])))
 
 # Fail the style-check for the following files:
 for filename in filenames:
     if filename == 'b':
-        print "*** cvs_check: some style errors in: %s" % filename
+        print("*** cvs_check: some style errors in: %s" % filename)
         sys.exit(1)

--- a/testsuite/tests/M524-010__colliding_files/cvs_check.py
+++ b/testsuite/tests/M524-010__colliding_files/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/M606-034__merge_commit_combined/cvs_check.py
+++ b/testsuite/tests/M606-034__merge_commit_combined/cvs_check.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """A dummy cvs_check program...
 """
+from __future__ import print_function
 import sys
 import os.path
 
@@ -8,9 +9,9 @@ filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # In this testcase, we expect the hooks to only ever call this script
 # to check one file, and one file only: foo.c.  For anything else,
@@ -18,5 +19,4 @@ print >> sys.stderr, "cvs_check: %s < %s" % (
 for filename in filenames:
     base_filename = os.path.basename(filename)
     if base_filename != 'foo.c':
-        print >> sys.stderr, \
-            'cvs_check ERROR: %s is missing a copyright header' % base_filename
+        print('cvs_check ERROR: %s is missing a copyright header' % base_filename, file=sys.stderr)

--- a/testsuite/tests/M606-034__precommit_check_wrong_file/cvs_check.py
+++ b/testsuite/tests/M606-034__precommit_check_wrong_file/cvs_check.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 """A dummy cvs_check program...
 """
+from __future__ import print_function
 import sys
 import os.path
 
@@ -8,9 +9,9 @@ filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print >> sys.stderr, "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])), file=sys.stderr)
 
 # In this testcase, we expect the hooks to only ever call this script
 # to check one file, and one file only: foo.c.  For anything else,
@@ -18,6 +19,5 @@ print >> sys.stderr, "cvs_check: %s < %s" % (
 for filename in filenames:
     base_filename = os.path.basename(filename)
     if base_filename != 'foo.c':
-        print >> sys.stderr, \
-                ('cvs_check ERROR: %s is missing a copyright header'
-                 % base_filename)
+        print(('cvs_check ERROR: %s is missing a copyright header'
+                 % base_filename), file=sys.stderr)

--- a/testsuite/tests/M903-031__concurrent_update/cvs_check.py
+++ b/testsuite/tests/M903-031__concurrent_update/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/MA09-043__alternate_style_checker/alt_style_checker.py
+++ b/testsuite/tests/MA09-043__alternate_style_checker/alt_style_checker.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "alt_style_checker: %s < %s" % (
+print("alt_style_checker: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/MA09-043__style_check_nested_file/cvs_check.py
+++ b/testsuite/tests/MA09-043__style_check_nested_file/cvs_check.py
@@ -4,24 +4,25 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
         ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-        ' '.join(["`%s'" % arg for arg in filenames]))
+        ' '.join(["`%s'" % arg for arg in filenames])))
 
 # Also, to verify that the file to be checked is accessible from
 # the style checker, dump its contents. This also allows to verify
 # that it's the right version of the file, btw.
 for filename in filenames:
-    print "File `%s' contains:" % filename
+    print("File `%s' contains:" % filename)
     with open(filename, 'r') as fd:
-	print fd.read()
-    print "--- Done ---"
+	print(fd.read())
+    print("--- Done ---")
 
 # And simulate a rejection.  Passing a relative path of the filename
 # is really only useful when the style-check detects some errors.

--- a/testsuite/tests/MC16-012__missing_info_dir/cvs_check.py
+++ b/testsuite/tests/MC16-012__missing_info_dir/cvs_check.py
@@ -4,15 +4,16 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])))
 
 # We should never be called for file `b', because the user requested
 # that this file not have pre-commit checks run on it (via a .gitattribute
@@ -20,5 +21,5 @@ print "cvs_check: %s < %s" % (
 
 for filename in filenames:
     if filename.endswith('/b'):
-	print "Error: Style violations detected in file: %s" % filename
+	print("Error: Style violations detected in file: %s" % filename)
 	sys.exit(1)

--- a/testsuite/tests/MC20-031__no_meta_config_file/cvs_check.py
+++ b/testsuite/tests/MC20-031__no_meta_config_file/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/MC25-004__new_branch_silent_commits/cvs_check.py
+++ b/testsuite/tests/MC25-004__new_branch_silent_commits/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/MC27-005__meta_config_update/cvs_check.py
+++ b/testsuite/tests/MC27-005__meta_config_update/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/MC27-006__meta_config_branch_create/cvs_check.py
+++ b/testsuite/tests/MC27-006__meta_config_branch_create/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/N110-019__new_branch_with_merge/cvs_check.py
+++ b/testsuite/tests/N110-019__new_branch_with_merge/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/N114-003__nested_gitattributes/cvs_check.py
+++ b/testsuite/tests/N114-003__nested_gitattributes/cvs_check.py
@@ -1,17 +1,18 @@
 #! /usr/bin/env python
 """A dummy cvs_check program.
 """
+from __future__ import print_function
 import sys
 
 filenames = sys.stdin.read().splitlines(False)
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in filenames]))
+    ' '.join(["`%s'" % arg for arg in filenames])))
 
 for filename in filenames:
     if filename.endswith('test.py'):
-        print "cvs_check: `%s' is violating restriction A.3.1(b)" % filename
+        print("cvs_check: `%s' is violating restriction A.3.1(b)" % filename)
         sys.exit(1)

--- a/testsuite/tests/N213-060__post-receive_from_email/cvs_check.py
+++ b/testsuite/tests/N213-060__post-receive_from_email/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/NC07-001__mailinglist_script/email_to.py
+++ b/testsuite/tests/NC07-001__mailinglist_script/email_to.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+from __future__ import print_function
 import sys
 
 ML_MAP = {'bfd': 'bfd-cvs@example.com',
@@ -38,4 +39,4 @@ if not result:
     # No files given, return EVERYONE
     result = EVERYONE
 
-print '\n'.join(sorted(result))
+print('\n'.join(sorted(result)))

--- a/testsuite/tests/NC20-011__commit_filer/cvs_check.py
+++ b/testsuite/tests/NC20-011__commit_filer/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/P329-007__noemail_fast_forward_merge/cvs_check.py
+++ b/testsuite/tests/P329-007__noemail_fast_forward_merge/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/P426-035__no_precommit_check_in_rh/cvs_check.py
+++ b/testsuite/tests/P426-035__no_precommit_check_in_rh/cvs_check.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python
 """A dummy cvs_check program that passes all files.
 """
+from __future__ import print_function
 # There should not be any file to check, so this script should never
 # be called. Return an error if it happens.
 import sys
 
-print('ERROR: cvs_check called for file(s): %s' %
-      ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+print(('ERROR: cvs_check called for file(s): %s' %
+      ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))
 sys.exit(1)

--- a/testsuite/tests/P526-066__style_checks_selection/cvs_check.py
+++ b/testsuite/tests/P526-066__style_checks_selection/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/P812-021__gerrit_edit_in_place/cvs_check.py
+++ b/testsuite/tests/P812-021__gerrit_edit_in_place/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/PB01-006__no-tn-check_instead_of_tn/cvs_check.py
+++ b/testsuite/tests/PB01-006__no-tn-check_instead_of_tn/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/Q119-043__multiline_config/cvs_check.py
+++ b/testsuite/tests/Q119-043__multiline_config/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/Q224-008__special_char_in_filename/cvs_check.py
+++ b/testsuite/tests/Q224-008__special_char_in_filename/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/Q314-009__frozen_ref_multiple/cvs_check.py
+++ b/testsuite/tests/Q314-009__frozen_ref_multiple/cvs_check.py
@@ -4,10 +4,11 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/Q314-009__frozen_ref_single/cvs_check.py
+++ b/testsuite/tests/Q314-009__frozen_ref_single/cvs_check.py
@@ -4,10 +4,11 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/Q608-030__no_style_check_config/cvs_check.py
+++ b/testsuite/tests/Q608-030__no_style_check_config/cvs_check.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 """A dummy cvs_check program that fails all files.
 """
+from __future__ import print_function
 import sys
 
 for arg in sys.stdin.read().splitlines(False):
-    print "%s: bad style, please fix." % arg
+    print("%s: bad style, please fix." % arg)
 sys.exit(1)

--- a/testsuite/tests/QB08-047__push_revert_commit/cvs_check.py
+++ b/testsuite/tests/QB08-047__push_revert_commit/cvs_check.py
@@ -1,16 +1,16 @@
 #! /usr/bin/env python
 """A dummy cvs_check program that FAILs all files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))
 
 filenames = sys.stdin.read().splitlines(False)
 
-print >> sys.stderr, \
-    'ERROR: %s: Copyright year in header is not up to date' % filenames[0]
+print('ERROR: %s: Copyright year in header is not up to date' % filenames[0], file=sys.stderr)
 sys.exit(1)

--- a/testsuite/tests/QB25-001__not_ISO_8859-15/cvs_check.py
+++ b/testsuite/tests/QB25-001__not_ISO_8859-15/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/QB25-001__tn_at_word_boundary/cvs_check.py
+++ b/testsuite/tests/QB25-001__tn_at_word_boundary/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/QC13-022__checker_config_on_its_own/cvs_check.py
+++ b/testsuite/tests/QC13-022__checker_config_on_its_own/cvs_check.py
@@ -5,13 +5,14 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))
 if len(sys.argv) > 2 and sys.argv[1] in ('--config', '-c'):
     with open(sys.argv[2]) as f:
-        print f.read()
+        print(f.read())

--- a/testsuite/tests/T209-003__custom_naming_delete_branch_custom_name_not_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_delete_branch_custom_name_not_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_delete_branch_custom_name_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_delete_branch_custom_name_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_delete_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_delete_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_new_branch_custom_name_not_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_new_branch_custom_name_not_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_new_branch_custom_name_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_new_branch_custom_name_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_new_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_new_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_update_branch_custom_name_not_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_update_branch_custom_name_not_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_update_branch_custom_name_recognized/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_update_branch_custom_name_recognized/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_update_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_update_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__custom_naming_update_tag/cvs_check.py
+++ b/testsuite/tests/T209-003__custom_naming_update_tag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_delete_branch_custom_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_delete_branch_custom_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_delete_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_delete_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_new_branch_custom_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_new_branch_custom_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_new_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_new_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_update_branch_custom_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_update_branch_custom_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_update_branch_std_name/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_update_branch_std_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__only_custom_naming_update_tag/cvs_check.py
+++ b/testsuite/tests/T209-003__only_custom_naming_update_tag/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-003__push_tag_as_branch/cvs_check.py
+++ b/testsuite/tests/T209-003__push_tag_as_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-004__disallow_delete_any_branch/cvs_check.py
+++ b/testsuite/tests/T209-004__disallow_delete_any_branch/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to verify
 that the script was called with the correct arguments and
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-004__disallow_delete_some_branches/cvs_check.py
+++ b/testsuite/tests/T209-004__disallow_delete_some_branches/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to verify
 that the script was called with the correct arguments and
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T209-004__disallow_delete_with_tip/cvs_check.py
+++ b/testsuite/tests/T209-004__disallow_delete_with_tip/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T227-003__meta_config_is_immediate/cvs_check.py
+++ b/testsuite/tests/T227-003__meta_config_is_immediate/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T227-003__meta_config_update_with_other_ref/cvs_check.py
+++ b/testsuite/tests/T227-003__meta_config_update_with_other_ref/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T227-003__pre_receive_hook/cvs_check.py
+++ b/testsuite/tests/T227-003__pre_receive_hook/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T227-003__pre_receive_hook_failure/cvs_check.py
+++ b/testsuite/tests/T227-003__pre_receive_hook_failure/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T227-003__push_multiple_branches/cvs_check.py
+++ b/testsuite/tests/T227-003__push_multiple_branches/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T314-004__new_branch_with_unusual_ref_name/cvs_check.py
+++ b/testsuite/tests/T314-004__new_branch_with_unusual_ref_name/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T329-003__delete_nonexistant_branch/cvs_check.py
+++ b/testsuite/tests/T329-003__delete_nonexistant_branch/cvs_check.py
@@ -4,11 +4,12 @@
 It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))
 

--- a/testsuite/tests/T512-052__empty_tuple_option/cvs_check.py
+++ b/testsuite/tests/T512-052__empty_tuple_option/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T512-052__multiple_filer_emails/cvs_check.py
+++ b/testsuite/tests/T512-052__multiple_filer_emails/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/T815-009__email_new_commits_only/cvs_check.py
+++ b/testsuite/tests/T815-009__email_new_commits_only/cvs_check.py
@@ -5,10 +5,11 @@ It also prints a trace on stdout, in order to allow us to allow us
 to verify that the script was called with the correct arguments
 for the correct files.
 """
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/TA21-016__combined_style_checking_of_revert_commit/cvs_check.py
+++ b/testsuite/tests/TA21-016__combined_style_checking_of_revert_commit/cvs_check.py
@@ -3,10 +3,11 @@
 
 It also prints a trace on stdout, in order to allow us to allow us
 to verify when the script was called, and with what arguments."""
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))

--- a/testsuite/tests/TA21-016__combined_style_checking_push_tag/cvs_check.py
+++ b/testsuite/tests/TA21-016__combined_style_checking_push_tag/cvs_check.py
@@ -3,10 +3,11 @@
 
 It also prints a trace on stdout, in order to allow us to allow us
 to verify when the script was called, and with what arguments."""
+from __future__ import print_function
 import sys
 
 # To help with testing, print a trace containing the name of the module
 # and the names of the files being checked.
-print "cvs_check: %s < %s" % (
+print("cvs_check: %s < %s" % (
     ' '.join(["`%s'" % arg for arg in sys.argv[1:]]),
-    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)]))
+    ' '.join(["`%s'" % arg for arg in sys.stdin.read().splitlines(False)])))


### PR DESCRIPTION
In preparation for the transition to Python 3, convert to using the
print function.  The special import

    from __future__ import print_function

in Python 2.7 makes "print" become the function and not the statement.
In Python 3, it has no effect.  Once the transition is done and we
exclusively use Python 3, we can simply remove the imports.

The testsuite shows no regressions.